### PR TITLE
Feature/v1.0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,27 +99,7 @@
 - release
   - 2025/07/10
 
-## v1.0.4
-
-🐛 noop
-
-## v1.0.3
-
-🐛 noop
-
-## v1.0.2
-
-🐛 noop
-
-## v1.0.1
-
-🐛 noop
-
-## v1.0.0
-
-🐛 noop
-
-- features
+- new features
   - `JsonSequenceFormatStream<T>`
     - `JSON Text <T>` Sequence -> object `T` Sequence
   - `JsonSequenceStream<T>`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # CHANGELOG
 
+## v1.0.8
+
+🐛 Bug fix for record separator (RS).
+
+- [npm:json-seq-stream@1.0.8](https://www.npmjs.com/package/json-seq-stream/v/1.0.8)  
+- [github:juner/json-seq-stream/releases/tag/v1.0.8](https://github.com/juner/json-seq-stream/releases/tag/v1.0.8)
+
+- release  
+  - 2025/08/29  
+
+- fix  
+  - Incorrectly used `\u00e1` instead of the correct `\u001e` for RS (Record Separator). 
+
 ## v1.0.7
 
 🚀 Supports `application/jsonl` (JSON Lines) and `application/x-ndjson` (NDJSON) and some generalization of functionality.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,28 +4,41 @@ import tseslint from "typescript-eslint";
 import json from "@eslint/json";
 import markdown from "@eslint/markdown";
 import { defineConfig } from "eslint/config";
+import stylistic from "@stylistic/eslint-plugin";
 
 
 export default defineConfig([
   {
     ignores: [
-      "dist/**.*"
+      `dist/**.*`
     ]
   },
-  { files: ["**/*.{js,mjs,cjs,ts,mts,cts}"], plugins: { js }, extends: ["js/recommended"] },
-  { files: ["**/*.{js,mjs,cjs,ts,mts,cts}"], languageOptions: { globals: { ...globals.browser, ...globals.node } } },
+  { files: [`**/*.{js,mjs,cjs,ts,mts,cts}`], plugins: { js }, extends: [`js/recommended`] },
+  { files: [`**/*.{js,mjs,cjs,ts,mts,cts}`], languageOptions: { globals: { ...globals.browser, ...globals.node } } },
   tseslint.configs.recommended,
   {
+    plugins: {
+      "@stylistic": stylistic,
+    },
     rules: {
-      "semi": "error",
+      "semi": [`error`],
+      "no-unused-vars": [`off`],
+      "@typescript-eslint/no-unused-vars": [`error`, {
+        argsIgnorePattern: `^_`,
+        // catch も同様のルール
+        caughtErrorsIgnorePattern: `^_`,
+        destructuredArrayIgnorePattern: `^_`,
+        varsIgnorePattern: `^_`,
+      }],
+      "@stylistic/quotes": [`error`, "double", { "allowTemplateLiterals": true }],
     }
   },
-  { files: ["**/*.json"], ignores: ["**/tsconfig.json", "package-lock.json"], plugins: { json }, language: "json/json", extends: ["json/recommended"] },
+  { files: [`**/*.json`], ignores: [`**/tsconfig.json`, `package-lock.json`], plugins: { json }, language: `json/json`, extends: [`json/recommended`] },
   {
     files: [
-      "**/tsconfig.json",
-      "**/*.code-workspace"
-    ], plugins: { json }, language: "json/jsonc", extends: ["json/recommended"]
+      `**/tsconfig.json`,
+      `**/*.code-workspace`
+    ], plugins: { json }, language: `json/jsonc`, extends: [`json/recommended`]
   },
-  { files: ["**/*.md"], plugins: { markdown }, language: "markdown/gfm", extends: ["markdown/recommended"] },
+  { files: [`**/*.md`], plugins: { markdown }, language: `markdown/gfm`, extends: [`markdown/recommended`] },
 ]);

--- a/eslint.config.mts
+++ b/eslint.config.mts
@@ -1,6 +1,6 @@
 import js from "@eslint/js";
 import globals from "globals";
-import tseslint, { ConfigWithExtends } from "typescript-eslint";
+import tseslint from "typescript-eslint";
 import json from "@eslint/json";
 import markdown from "@eslint/markdown";
 import { defineConfig } from "eslint/config";

--- a/eslint.config.mts
+++ b/eslint.config.mts
@@ -1,6 +1,6 @@
 import js from "@eslint/js";
 import globals from "globals";
-import tseslint from "typescript-eslint";
+import tseslint, { ConfigWithExtends } from "typescript-eslint";
 import json from "@eslint/json";
 import markdown from "@eslint/markdown";
 import { defineConfig } from "eslint/config";
@@ -15,7 +15,7 @@ export default defineConfig([
   },
   { files: [`**/*.{js,mjs,cjs,ts,mts,cts}`], plugins: { js }, extends: [`js/recommended`] },
   { files: [`**/*.{js,mjs,cjs,ts,mts,cts}`], languageOptions: { globals: { ...globals.browser, ...globals.node } } },
-  tseslint.configs.recommended,
+  tseslint.configs.recommended as unknown as Parameters<typeof defineConfig>,
   {
     plugins: {
       "@stylistic": stylistic,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "json-seq-stream",
-  "version": "1.0.4",
+  "version": "1.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "json-seq-stream",
-      "version": "1.0.4",
+      "version": "1.0.7",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.30.1",
         "@eslint/json": "^0.12.0",
         "@eslint/markdown": "^6.6.0",
+        "@stylistic/eslint-plugin": "^5.2.0",
         "@vitest/coverage-v8": "^3.2.4",
         "cpx": "^1.2.1",
         "eslint": "^9.30.1",
@@ -21,6 +22,9 @@
         "typescript-eslint": "^8.36.0",
         "vite": "^7.0.3",
         "vitest": "^3.2.4"
+      },
+      "engines": {
+        "node": "^24.x"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1256,6 +1260,54 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@stylistic/eslint-plugin": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-5.2.0.tgz",
+      "integrity": "sha512-RCEdbREv9EBiToUBQTlRhVYKG093I6ZnnQ990j08eJ6uRZh71DXkOnoxtTLfDQ6utVCVQzrhZFHZP0zfrfOIjA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.7.0",
+        "@typescript-eslint/types": "^8.37.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "estraverse": "^5.3.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=9.0.0"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin/node_modules/@typescript-eslint/types": {
+      "version": "8.37.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.37.0.tgz",
+      "integrity": "sha512-ax0nv7PUF9NOVPs+lmQ7yIE7IQmAf8LGcXbMvHX5Gm+YJUYNAl340XkGnrimxZ0elXyoQJuN5sbg6C4evKA4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/@types/chai": {
       "version": "5.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,7 +1,7 @@
 {
   "name": "json-seq-stream",
-  "version": "1.0.7",
-  "lockfileVersion": 3,
+  "version": "1.0.8",
+  "lockfileVersion": 4,
   "requires": true,
   "packages": {
     "": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-seq-stream",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "application/json-seq support stream / async iterator library",
   "type": "module",
   "main": "./index.js",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@eslint/js": "^9.30.1",
     "@eslint/json": "^0.12.0",
     "@eslint/markdown": "^6.6.0",
+    "@stylistic/eslint-plugin": "^5.2.0",
     "@vitest/coverage-v8": "^3.2.4",
     "cpx": "^1.2.1",
     "eslint": "^9.30.1",

--- a/src/SequenceToRecordStream.test.ts
+++ b/src/SequenceToRecordStream.test.ts
@@ -21,8 +21,8 @@ test("enqueue", async ({ expect }) => {
   (async () => {
     const writer = writable.getWriter();
     await writer.write(`T`);
-    await writer.write('');
-    await writer.write('HOGEFUGA');
+    await writer.write("");
+    await writer.write("HOGEFUGA");
     await writer.close();
   })();
   const text = await response.text();

--- a/src/TextJoinStream.test.ts
+++ b/src/TextJoinStream.test.ts
@@ -26,7 +26,7 @@ test("add empty start / end delimiter", async ({ expect }) => {
     await writer.close();
   })();
   const text = await response.text();
-  expect(text).equal(',,');
+  expect(text).equal(",,");
 });
 
 test("enqueue", async ({ expect }) => {

--- a/src/TextSplitStream.ts
+++ b/src/TextSplitStream.ts
@@ -52,7 +52,7 @@ function makeInternalTextSplitStream({ splitter, chunkEndSplit }: TextSplitStrea
 function makeSeparator(separater: string[] | string) {
   if (typeof separater === "string")
     separater = [separater];
-  const parts = separater.map(s => RegExp.escape(s)).join('|');
+  const parts = separater.map(s => RegExp.escape(s)).join("|");
   return {
     separator: new RegExp(`(${parts})`, "ug"),
     checker: new RegExp(`^(${parts})$`),

--- a/src/rfc7464.ts
+++ b/src/rfc7464.ts
@@ -8,7 +8,7 @@
  * @see https://datatracker.ietf.org/doc/html/rfc7464#section-2.2
  * @see https://datatracker.ietf.org/doc/html/rfc20
  */
-export const RS = "\u00e1";
+export const RS = "\u001e";
 
 /**
  * LF = %x0A; "line feed" (LF), see RFC 20

--- a/src/rfc7464.ts
+++ b/src/rfc7464.ts
@@ -8,14 +8,14 @@
  * @see https://datatracker.ietf.org/doc/html/rfc7464#section-2.2
  * @see https://datatracker.ietf.org/doc/html/rfc20
  */
-export const RS = '\u00e1';
+export const RS = "\u00e1";
 
 /**
  * LF = %x0A; "line feed" (LF), see RFC 20
  * @see https://datatracker.ietf.org/doc/html/rfc7464#section-2.2
  * @see https://datatracker.ietf.org/doc/html/rfc20
  */
-export const LF = '\n';
+export const LF = "\n";
 
 /**
  * The MIME media type for JSON text sequences is application/json-seq.


### PR DESCRIPTION
## v1.0.8

🐛 Bug fix for record separator (RS).

- [npm:json-seq-stream@1.0.8](https://www.npmjs.com/package/json-seq-stream/v/1.0.8)  
- [github:juner/json-seq-stream/releases/tag/v1.0.8](https://github.com/juner/json-seq-stream/releases/tag/v1.0.8)

- release  
  - 2025/08/29  

- fix  
  - Incorrectly used `\u00e1` instead of the correct `\u001e` for RS (Record Separator). 