### PR TITLE
テストにて 定数群 を import するのを辞める

### DIFF
--- a/eslint.config.mts
+++ b/eslint.config.mts
@@ -30,7 +30,7 @@ export default defineConfig([
         destructuredArrayIgnorePattern: `^_`,
         varsIgnorePattern: `^_`,
       }],
-      "@stylistic/quotes": [`error`, "double", { "allowTemplateLiterals": true }],
+      "@stylistic/quotes": [`error`, "double", { "allowTemplateLiterals": "always" }],
     }
   },
   { files: [`**/*.json`], ignores: [`**/tsconfig.json`, `package-lock.json`], plugins: { json }, language: `json/json`, extends: [`json/recommended`] },

--- a/src/InputJsonSequenceStream.test.ts
+++ b/src/InputJsonSequenceStream.test.ts
@@ -1,6 +1,5 @@
 import { test } from "vitest";
 import { InputJsonSequenceStream } from ".";
-import { LF, RS } from "./rfc7464";
 
 test("empty", async ({ expect }) => {
   type Value = {
@@ -17,7 +16,7 @@ test("enqueue", async ({ expect }) => {
     value: number;
   };
   const sequenceStream = new InputJsonSequenceStream<Value>();
-  const blob = new Blob([`${RS}{"value":30}${LF}${RS}{"value":3}`]);
+  const blob = new Blob([`\u001e{"value":30}\n\u001e{"value":3}`]);
   const file = new File([blob], "json-seq.json-seq", { type: "application/json-seq" });
   const url = URL.createObjectURL(file);
   await using stack = new AsyncDisposableStack();

--- a/src/InputLineFeedSeparattedSequenceStream.test.ts
+++ b/src/InputLineFeedSeparattedSequenceStream.test.ts
@@ -1,13 +1,12 @@
 import {test} from "vitest";
 import { InputLineFeedSeparattedSequenceStream } from "./InputLineFeedSeparattedSequenceStream";
-import { CRLF, LF } from "./jsonlines";
 
 test("enqueue", async ({ expect }) => {
   const { readable, writable } = new InputLineFeedSeparattedSequenceStream();
   const writer = writable.getWriter();
   const promises: Promise<unknown>[] = [];
   promises.push((async () => {
-    await writer.write(`${LF}TESTTESTTEST${CRLF}${LF}${LF}NEKONEKO${LF}INUINU`);
+    await writer.write(`\nTESTTESTTEST\r\n\n\nNEKONEKO\nINUINU`);
     await writer.close();
   })());
   const arrayWait = Array.fromAsync(readable.values());

--- a/src/OutputJsonSequenceStream.test.ts
+++ b/src/OutputJsonSequenceStream.test.ts
@@ -1,6 +1,5 @@
 import { test } from "vitest";
 import { OutputJsonSequenceStream } from ".";
-import { LF, MIME_TYPE, RS } from "./rfc7464";
 
 test("empty", async ({ expect }) => {
   type Value = {
@@ -24,12 +23,12 @@ test("enqueue", async ({ expect }) => {
     await writer.close();
   })();
   const text = await response.text();
-  expect(text).equal(`${RS}{"value":30}${LF}${RS}{"value":3}${LF}`);
+  expect(text).equal(`\u001e{"value":30}\n\u001e{"value":3}\n`);
 });
 
 function make<T>(options?: ConstructorParameters<typeof OutputJsonSequenceStream<T>>[0]) {
   const { readable, writable } = new OutputJsonSequenceStream(options);
   const response = new Response(readable);
-  response.headers.append("content-type", MIME_TYPE);
+  response.headers.append("content-type", "application/json-seq");
   return { writable, response };
 }

--- a/src/OutputTextJoinLineFeedSequenceStream.test.ts
+++ b/src/OutputTextJoinLineFeedSequenceStream.test.ts
@@ -1,6 +1,5 @@
 import { test } from "vitest";
 import { OutputTextJoinLineFeedSequenceStream } from ".";
-import { LF } from "./jsonlines";
 
 test("enqueue", async ({expect})=> {
   const {readable, writable} = new OutputTextJoinLineFeedSequenceStream();
@@ -14,5 +13,5 @@ test("enqueue", async ({expect})=> {
     await writer.close();
   })();
   const text = await response.text();
-  expect(text).equal(`🐈🐶${LF}🐒🐓${LF}🐕🐗`);
+  expect(text).equal(`🐈🐶\n🐒🐓\n🐕🐗`);
 });


### PR DESCRIPTION
流石に v1.0.8 の様な bugfix はしたくないので そこは分けたほうがよい