### PR TITLE
fix: use modern esm type resolution for consumers with NodeNext

### DIFF
--- a/src/InputJsonLinesStream.test.ts
+++ b/src/InputJsonLinesStream.test.ts
@@ -1,5 +1,5 @@
 import {test} from "vitest";
-import { InputJsonLinesStream } from ".";
+import { InputJsonLinesStream } from "./index.js";
 
 test("empty", async ({expect}) => {
   const {writable, readable} = new InputJsonLinesStream();

--- a/src/InputJsonLinesStream.ts
+++ b/src/InputJsonLinesStream.ts
@@ -1,7 +1,7 @@
-import { InputJsonSequenceParseStream } from "./InputJsonSequenceParseStream";
-import type { InputJsonSequenceParseStreamOptions } from "./InputJsonSequenceParseStream";
-import { InputLineFeedSeparattedSequenceStream } from "./InputLineFeedSeparattedSequenceStream";
-import type { InputLineFeedSeparattedSequenceStreamOptions } from "./InputLineFeedSeparattedSequenceStream";
+import { InputJsonSequenceParseStream } from "./InputJsonSequenceParseStream.js";
+import type { InputJsonSequenceParseStreamOptions } from "./InputJsonSequenceParseStream.js";
+import { InputLineFeedSeparattedSequenceStream } from "./InputLineFeedSeparattedSequenceStream.js";
+import type { InputLineFeedSeparattedSequenceStreamOptions } from "./InputLineFeedSeparattedSequenceStream.js";
 
 export type InputJsonLinesStreamOptions<T> = { label?: string } & TextDecoderOptions & InputLineFeedSeparattedSequenceStreamOptions & InputJsonSequenceParseStreamOptions<T>
 

--- a/src/InputJsonSequenceParseStream.test.ts
+++ b/src/InputJsonSequenceParseStream.test.ts
@@ -1,5 +1,5 @@
 import { test } from "vitest";
-import { InputJsonSequenceParseStream } from ".";
+import { InputJsonSequenceParseStream } from "./index.js";
 
 test("empty", async ({ expect }) => {
   const { readable, writable } = new InputJsonSequenceParseStream();

--- a/src/InputJsonSequenceParseStream.ts
+++ b/src/InputJsonSequenceParseStream.ts
@@ -1,5 +1,5 @@
-import { ParseStream } from "./ParseStream";
-import type { ParseStreamOptions } from "./ParseStream";
+import { ParseStream } from "./ParseStream.js";
+import type { ParseStreamOptions } from "./ParseStream.js";
 
 export type InputJsonSequenceParseStreamOptions<T> = Partial<ParseStreamOptions<T>>;
 

--- a/src/InputJsonSequenceStream.test.ts
+++ b/src/InputJsonSequenceStream.test.ts
@@ -1,5 +1,5 @@
 import { test } from "vitest";
-import { InputJsonSequenceStream } from ".";
+import { InputJsonSequenceStream } from "./index.js";
 
 test("empty", async ({ expect }) => {
   type Value = {

--- a/src/InputJsonSequenceStream.ts
+++ b/src/InputJsonSequenceStream.ts
@@ -1,7 +1,7 @@
-import { InputJsonSequenceParseStream } from "./InputJsonSequenceParseStream";
-import type { InputJsonSequenceParseStreamOptions } from "./InputJsonSequenceParseStream";
-import { InputRecordSequenceStream, } from "./InputRecordSequenceStream";
-import type { InputRecordSequenceStreamOptions } from "./InputRecordSequenceStream";
+import { InputJsonSequenceParseStream } from "./InputJsonSequenceParseStream.js";
+import type { InputJsonSequenceParseStreamOptions } from "./InputJsonSequenceParseStream.js";
+import { InputRecordSequenceStream, } from "./InputRecordSequenceStream.js";
+import type { InputRecordSequenceStreamOptions } from "./InputRecordSequenceStream.js";
 
 export type InputJsonSequenceStreamOptions<T> = { label?: string } & TextDecoderOptions & InputJsonSequenceParseStreamOptions<T> & InputRecordSequenceStreamOptions;
 

--- a/src/InputLineFeedSeparattedSequenceStream.test.ts
+++ b/src/InputLineFeedSeparattedSequenceStream.test.ts
@@ -1,5 +1,5 @@
 import {test} from "vitest";
-import { InputLineFeedSeparattedSequenceStream } from "./InputLineFeedSeparattedSequenceStream";
+import { InputLineFeedSeparattedSequenceStream } from "./InputLineFeedSeparattedSequenceStream.js";
 
 test("enqueue", async ({ expect }) => {
   const { readable, writable } = new InputLineFeedSeparattedSequenceStream();

--- a/src/InputLineFeedSeparattedSequenceStream.ts
+++ b/src/InputLineFeedSeparattedSequenceStream.ts
@@ -1,5 +1,5 @@
-import { LF, CRLF } from "./jsonlines";
-import { TextSplitStream, TextSplitStreamOptions } from "./TextSplitStream";
+import { LF, CRLF } from "./jsonlines.js";
+import { TextSplitStream, TextSplitStreamOptions } from "./TextSplitStream.js";
 
 export type InputLineFeedSeparattedSequenceStreamOptions = Partial<TextSplitStreamOptions>;
 

--- a/src/InputRecordSequenceStream.test.ts
+++ b/src/InputRecordSequenceStream.test.ts
@@ -1,6 +1,6 @@
 import { test } from "vitest";
-import { InputRecordSequenceStream } from ".";
-import { LF, RS } from "./rfc7464";
+import { InputRecordSequenceStream } from "./index.js";
+import { LF, RS } from "./rfc7464.js";
 
 test("empty", async ({expect}) => {
   const {readable, writable} = new InputRecordSequenceStream();

--- a/src/InputRecordSequenceStream.ts
+++ b/src/InputRecordSequenceStream.ts
@@ -1,6 +1,6 @@
-import { RecordToSequenceStream } from "./RecordToSequenceStream";
-import type { RecordToSequenceStreamOptions } from "./RecordToSequenceStream";
-import { LF, RS } from "./rfc7464";
+import { RecordToSequenceStream } from "./RecordToSequenceStream.js";
+import type { RecordToSequenceStreamOptions } from "./RecordToSequenceStream.js";
+import { LF, RS } from "./rfc7464.js";
 
 
 export type InputRecordSequenceStreamOptions = Partial<RecordToSequenceStreamOptions>;

--- a/src/OutputJsonLinesStream.test.ts
+++ b/src/OutputJsonLinesStream.test.ts
@@ -1,6 +1,6 @@
 import { test } from "vitest";
-import { OutputJsonLinesStream } from ".";
-import { MIME_TYPE } from "./jsonlines";
+import { OutputJsonLinesStream } from "./index.js";
+import { MIME_TYPE } from "./jsonlines.js";
 
 test("empty", async ({ expect }) => {
   const { writable, response } = make();

--- a/src/OutputJsonLinesStream.ts
+++ b/src/OutputJsonLinesStream.ts
@@ -1,7 +1,7 @@
-import { OutputJsonSequenceStringifyStream } from "./OutputJsonSequenceStringifyStream";
-import type { OutputJsonSequenceStringifyStreamOptions } from "./OutputJsonSequenceStringifyStream";
-import { OutputTextJoinLineFeedSequenceStream } from "./OutputTextJoinLineFeedSequenceStream";
-import type { OutputTextJoinLineFeedSequenceStreamOptions } from "./OutputTextJoinLineFeedSequenceStream";
+import { OutputJsonSequenceStringifyStream } from "./OutputJsonSequenceStringifyStream.js";
+import type { OutputJsonSequenceStringifyStreamOptions } from "./OutputJsonSequenceStringifyStream.js";
+import { OutputTextJoinLineFeedSequenceStream } from "./OutputTextJoinLineFeedSequenceStream.js";
+import type { OutputTextJoinLineFeedSequenceStreamOptions } from "./OutputTextJoinLineFeedSequenceStream.js";
 
 export type OutputJsonLinesStreamOptions<T> = OutputJsonSequenceStringifyStreamOptions<T> & OutputTextJoinLineFeedSequenceStreamOptions;
 

--- a/src/OutputJsonSequenceStream.test.ts
+++ b/src/OutputJsonSequenceStream.test.ts
@@ -1,5 +1,5 @@
 import { test } from "vitest";
-import { OutputJsonSequenceStream } from ".";
+import { OutputJsonSequenceStream } from "./index.js";
 
 test("empty", async ({ expect }) => {
   type Value = {

--- a/src/OutputJsonSequenceStream.ts
+++ b/src/OutputJsonSequenceStream.ts
@@ -1,7 +1,7 @@
-import { OutputJsonSequenceStringifyStream } from "./OutputJsonSequenceStringifyStream";
-import type { OutputJsonSequenceStringifyStreamOptions } from "./OutputJsonSequenceStringifyStream";
-import { OutputRecordSequenceStream } from "./OutputRecordSequenceStream";
-import type { OutputRecordSequenceStreamOptions } from "./OutputRecordSequenceStream";
+import { OutputJsonSequenceStringifyStream } from "./OutputJsonSequenceStringifyStream.js";
+import type { OutputJsonSequenceStringifyStreamOptions } from "./OutputJsonSequenceStringifyStream.js";
+import { OutputRecordSequenceStream } from "./OutputRecordSequenceStream.js";
+import type { OutputRecordSequenceStreamOptions } from "./OutputRecordSequenceStream.js";
 
 export type OutputJsonSequenceStreamOptions<T> = OutputJsonSequenceStringifyStreamOptions<T> & OutputRecordSequenceStreamOptions;
 

--- a/src/OutputJsonSequenceStringifyStream.test.ts
+++ b/src/OutputJsonSequenceStringifyStream.test.ts
@@ -1,5 +1,5 @@
 import { test } from "vitest";
-import { OutputJsonSequenceStringifyStream } from ".";
+import { OutputJsonSequenceStringifyStream } from "./index.js";
 
 test("empty", async ({ expect }) => {
   const { readable, writable } = new OutputJsonSequenceStringifyStream();

--- a/src/OutputJsonSequenceStringifyStream.ts
+++ b/src/OutputJsonSequenceStringifyStream.ts
@@ -1,5 +1,5 @@
-import { StringifyStream } from "./StringifyStream";
-import type { StringifyStreamOptions } from "./StringifyStream";
+import { StringifyStream } from "./StringifyStream.js";
+import type { StringifyStreamOptions } from "./StringifyStream.js";
 
 export type OutputJsonSequenceStringifyStreamOptions<T> = Partial<StringifyStreamOptions<T>>;
 

--- a/src/OutputRecordSequenceStream.test.ts
+++ b/src/OutputRecordSequenceStream.test.ts
@@ -1,6 +1,6 @@
 import { test } from "vitest";
-import { OutputRecordSequenceStream } from ".";
-import { LF, RS } from "./rfc7464";
+import { OutputRecordSequenceStream } from "./index.js";
+import { LF, RS } from "./rfc7464.js";
 
 test("empty", async ({ expect }) => {
   const { response, writable } = make();

--- a/src/OutputRecordSequenceStream.ts
+++ b/src/OutputRecordSequenceStream.ts
@@ -1,6 +1,6 @@
-import { LF, RS } from "./rfc7464";
-import { SequenceToRecordStream } from "./SequenceToRecordStream";
-import type { SequenceToRecordStreamOptions } from "./SequenceToRecordStream";
+import { LF, RS } from "./rfc7464.js";
+import { SequenceToRecordStream } from "./SequenceToRecordStream.js";
+import type { SequenceToRecordStreamOptions } from "./SequenceToRecordStream.js";
 
 const RECORD_BEGIN = RS;
 const RECORD_END = LF;

--- a/src/OutputTextJoinLineFeedSequenceStream.test.ts
+++ b/src/OutputTextJoinLineFeedSequenceStream.test.ts
@@ -1,5 +1,5 @@
 import { test } from "vitest";
-import { OutputTextJoinLineFeedSequenceStream } from ".";
+import { OutputTextJoinLineFeedSequenceStream } from "./index.js";
 
 test("enqueue", async ({expect})=> {
   const {readable, writable} = new OutputTextJoinLineFeedSequenceStream();

--- a/src/OutputTextJoinLineFeedSequenceStream.ts
+++ b/src/OutputTextJoinLineFeedSequenceStream.ts
@@ -1,6 +1,6 @@
-import { LF } from "./jsonlines";
-import { TextJoinStream } from "./TextJoinStream";
-import type { TextJoinStreamOptions } from "./TextJoinStream";
+import { LF } from "./jsonlines.js";
+import { TextJoinStream } from "./TextJoinStream.js";
+import type { TextJoinStreamOptions } from "./TextJoinStream.js";
 
 export type OutputTextJoinLineFeedSequenceStreamOptions = Partial<TextJoinStreamOptions>;
 

--- a/src/ParseStream.test.ts
+++ b/src/ParseStream.test.ts
@@ -1,5 +1,5 @@
 import { test } from "vitest";
-import { ParseStream } from ".";
+import { ParseStream } from "./index.js";
 
 test("empty", async ({ expect }) => {
   const { readable, writable } = new ParseStream({

--- a/src/ParseStream.ts
+++ b/src/ParseStream.ts
@@ -1,5 +1,5 @@
 
-import type { TransformStreamConstructor } from "./TransformStreamConstructor";
+import type { TransformStreamConstructor } from "./TransformStreamConstructor.js";
 
 export type ParseStreamOptions<T> = {
   /** A function that converts a string to type `T`. */

--- a/src/RecordToSequenceStream.test.ts
+++ b/src/RecordToSequenceStream.test.ts
@@ -1,5 +1,5 @@
 import { test } from "vitest";
-import { RecordToSequenceStream } from ".";
+import { RecordToSequenceStream } from "./index.js";
 
 test("empty", async ({ expect }) => {
   const { readable, writable } = new RecordToSequenceStream({

--- a/src/RecordToSequenceStream.ts
+++ b/src/RecordToSequenceStream.ts
@@ -1,4 +1,4 @@
-import type { TransformStreamConstructor } from "./TransformStreamConstructor";
+import type { TransformStreamConstructor } from "./TransformStreamConstructor.js";
 
 const modes = {
   begin: "begin",

--- a/src/SequenceToRecordStream.test.ts
+++ b/src/SequenceToRecordStream.test.ts
@@ -1,5 +1,5 @@
 import { test } from "vitest";
-import { SequenceToRecordStream } from "./SequenceToRecordStream";
+import { SequenceToRecordStream } from "./SequenceToRecordStream.js";
 
 test("empty", async ({ expect }) => {
   const { writable, response } = make({

--- a/src/SequenceToRecordStream.ts
+++ b/src/SequenceToRecordStream.ts
@@ -1,4 +1,4 @@
-import type { TransformStreamConstructor } from "./TransformStreamConstructor";
+import type { TransformStreamConstructor } from "./TransformStreamConstructor.js";
 
 export type SequenceToRecordStreamOptions = {
   /** record begin character */

--- a/src/StringifyStream.test.ts
+++ b/src/StringifyStream.test.ts
@@ -1,5 +1,5 @@
 import { test } from "vitest";
-import { StringifyStream } from ".";
+import { StringifyStream } from "./index.js";
 
 test("empty", async ({ expect }) => {
   const { readable, writable } = new StringifyStream({

--- a/src/StringifyStream.ts
+++ b/src/StringifyStream.ts
@@ -1,4 +1,4 @@
-import type { TransformStreamConstructor } from "./TransformStreamConstructor";
+import type { TransformStreamConstructor } from "./TransformStreamConstructor.js";
 
 export type StringifyStreamOptions<T> = {
   /** A function that converts a `T` value to a string. */

--- a/src/TextJoinStream.test.ts
+++ b/src/TextJoinStream.test.ts
@@ -1,5 +1,5 @@
 import { test } from "vitest";
-import { TextJoinStream } from "./TextJoinStream";
+import { TextJoinStream } from "./TextJoinStream.js";
 
 test("empty", async ({ expect }) => {
   const { response, writable } = make({

--- a/src/TextJoinStream.ts
+++ b/src/TextJoinStream.ts
@@ -1,4 +1,4 @@
-import type { TransformStreamConstructor } from "./TransformStreamConstructor";
+import type { TransformStreamConstructor } from "./TransformStreamConstructor.js";
 
 export type TextJoinStreamOptions = {
   /** delimiter character */

--- a/src/TextSplitStream.test.ts
+++ b/src/TextSplitStream.test.ts
@@ -1,5 +1,5 @@
 import { test } from "vitest";
-import { TextSplitStream } from ".";
+import { TextSplitStream } from "./index.js";
 
 test("empty", async ({ expect }) => {
   const { readable, writable } = new TextSplitStream({

--- a/src/TextSplitStream.ts
+++ b/src/TextSplitStream.ts
@@ -1,4 +1,4 @@
-import type { TransformStreamConstructor } from "./TransformStreamConstructor";
+import type { TransformStreamConstructor } from "./TransformStreamConstructor.js";
 
 export type TextSplitStreamOptions = {
   /** separator character */

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,40 +1,39 @@
-
 //#region split / join
-export * from "./TextSplitStream";
-export * from "./TextJoinStream";
+export * from "./TextSplitStream.js";
+export * from "./TextJoinStream.js";
 //#endregion
 
 //#region application/json-seq
-export * from "./InputJsonSequenceStream";
-export * from "./OutputJsonSequenceStream";
+export * from "./InputJsonSequenceStream.js";
+export * from "./OutputJsonSequenceStream.js";
 //#endregion
 
 //#region Json <-> Sequence
-export * from "./InputJsonSequenceParseStream";
-export * from "./OutputJsonSequenceStringifyStream";
+export * from "./InputJsonSequenceParseStream.js";
+export * from "./OutputJsonSequenceStringifyStream.js";
 //#endregion
 
 //#region RS / LF record
-export * from "./InputRecordSequenceStream";
-export * from "./OutputRecordSequenceStream";
+export * from "./InputRecordSequenceStream.js";
+export * from "./OutputRecordSequenceStream.js";
 //#endregion
 
 //#region JsonLines
-export * from "./InputJsonLinesStream";
-export * from "./OutputJsonLinesStream";
+export * from "./InputJsonLinesStream.js";
+export * from "./OutputJsonLinesStream.js";
 //#endregion
 
 //#region LF (or CRLF) split / join
-export * from "./InputLineFeedSeparattedSequenceStream";
-export * from "./OutputTextJoinLineFeedSequenceStream";
+export * from "./InputLineFeedSeparattedSequenceStream.js";
+export * from "./OutputTextJoinLineFeedSequenceStream.js";
 //#endregion
 
 //#region sequence -> record / record -> sequence
-export * from "./SequenceToRecordStream";
-export * from "./RecordToSequenceStream";
+export * from "./SequenceToRecordStream.js";
+export * from "./RecordToSequenceStream.js";
 //#endregion
 
 // #region object -> text / text -> object
-export * from "./StringifyStream";
-export * from "./ParseStream";
+export * from "./StringifyStream.js";
+export * from "./ParseStream.js";
 // #endregion

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2022",
     "useDefineForClassFields": true,
-    "module": "ESNext",
+    "module": "NodeNext",
     "lib": [
       "ESNext",
       "DOM",
@@ -10,8 +10,8 @@
     ],
     "skipLibCheck": true,
     /* Bundler mode */
-    "moduleResolution": "bundler",
-    "allowImportingTsExtensions": true,
+    "moduleResolution": "NodeNext",
+    "allowImportingTsExtensions": false,
     "moduleDetection": "force",
     "emitDeclarationOnly": true,
     "declaration": true,


### PR DESCRIPTION
Hey!

Version `1.0.7` was published with `index.d.ts` in `dist/` containing file extensions for the imports (ie `export * from "./TextSplitStream.d.ts";`. Version `1.0.8` was published without those file extensions (ie `export * from "./TextSplitStream";`, which breaks imports for consumers using `NodeNext` module resolution. This PR switches the project to `NodeNext`, which is still compatible with `bundler` resolution for consumers using bundlers. This should allow compatibility for people both using bundlers and those not.

Thank you!